### PR TITLE
feat: disable list like behaviour

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -136,7 +136,7 @@ class RedisIndexer(Executor):
                 )
 
     @requests(on='/filter')
-    def filter(self, parameters: str, **kwargs):
+    def filter(self, parameters: Dict, **kwargs):
         """
         Query documents from the indexer by the filter `query` object in parameters. The `query` object must follow the
         specifications in the `find` method of `DocumentArray` using Redis: https://docarray.jina.ai/advanced/document-store/redis/#search-by-filter-query

--- a/executor.py
+++ b/executor.py
@@ -72,6 +72,7 @@ class RedisIndexer(Executor):
                 'block_size': block_size,
                 'initial_cap': initial_cap,
                 'columns': columns,
+                'list_like': False,
             },
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-docarray[redis]>=0.19.2
+docarray[redis]>=0.20.0
 jina>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-docarray[redis]>=0.19.0
+docarray[redis]>=0.19.2
 jina>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[redis]>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[redis]>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-docarray[redis]
+docarray[redis]>=0.19.0
+git+https://github.com/jina-ai/jina.git@master

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.2
-docarray>=0.13.18
+docarray>=0.19.0
+git+https://github.com/jina-ai/jina.git@master

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
-docarray>=0.19.2
+docarray>=0.20.0
 jina>=3.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
-docarray>=0.20.0
+docarray[redis]>=0.20.0
 jina>=3.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
-docarray>=0.19.0
+docarray>=0.19.2
 jina>=3.11.2

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -68,7 +68,6 @@ def test_update(docs, update_docs, docker_compose):
 
     # update first doc
     indexer.update(update_docs)
-    assert indexer._index[0].id == 'doc1'
     assert indexer._index['doc1'].text == 'modified'
 
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -104,11 +104,8 @@ def test_filter(docker_compose):
     assert result[0].tags['x'] == 0.8
 
 
-@pytest.mark.parametrize(
-    'metric, metric_name',
-    [('L2', 'euclid_distance'), ('COSINE', 'cosine_distance')],
-)
-def test_search(metric, metric_name, docs, docker_compose):
+@pytest.mark.parametrize('metric', ['L2', 'COSINE'],)
+def test_search(metric, docs, docker_compose):
     # test general/normal case
     indexer = RedisIndexer(index_name='test6', distance=metric)
     indexer.index(docs)
@@ -116,10 +113,9 @@ def test_search(metric, metric_name, docs, docker_compose):
     indexer.search(query)
 
     for doc in query:
-        similarities = [t[metric_name].value for t in doc.matches[:, 'scores']]
-        print(f"similarities = {similarities}")
-        assert sorted(similarities) == similarities
-        assert len(similarities) == len(docs)
+        distances = [t['score'].value for t in doc.matches[:, 'scores']]
+        assert sorted(distances) == distances
+        assert len(distances) == len(docs)
 
 
 @pytest.mark.parametrize('limit', [1, 2, 3])

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -104,7 +104,7 @@ def test_filter(docker_compose):
     assert result[0].tags['x'] == 0.8
 
 
-@pytest.mark.parametrize('metric', ['L2', 'COSINE'],)
+@pytest.mark.parametrize('metric', ['L2', 'IP', 'COSINE'],)
 def test_search(metric, docs, docker_compose):
     # test general/normal case
     indexer = RedisIndexer(index_name='test6', distance=metric)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -15,12 +15,12 @@ compose_yml = os.path.abspath(os.path.join(cur_dir, '../docker-compose.yml'))
 def docs():
     return DocumentArray(
         [
-            Document(id='doc1', embedding=np.random.rand(3)),
-            Document(id='doc2', embedding=np.random.rand(3)),
-            Document(id='doc3', embedding=np.random.rand(3)),
-            Document(id='doc4', embedding=np.random.rand(3)),
-            Document(id='doc5', embedding=np.random.rand(3)),
-            Document(id='doc6', embedding=np.random.rand(3)),
+            Document(id='doc1', embedding=np.random.rand(128)),
+            Document(id='doc2', embedding=np.random.rand(128)),
+            Document(id='doc3', embedding=np.random.rand(128)),
+            Document(id='doc4', embedding=np.random.rand(128)),
+            Document(id='doc5', embedding=np.random.rand(128)),
+            Document(id='doc6', embedding=np.random.rand(128)),
         ]
     )
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -15,12 +15,12 @@ compose_yml = os.path.abspath(os.path.join(cur_dir, '../docker-compose.yml'))
 def docs():
     return DocumentArray(
         [
-            Document(id='doc1', embedding=np.random.rand(128)),
-            Document(id='doc2', embedding=np.random.rand(128)),
-            Document(id='doc3', embedding=np.random.rand(128)),
-            Document(id='doc4', embedding=np.random.rand(128)),
-            Document(id='doc5', embedding=np.random.rand(128)),
-            Document(id='doc6', embedding=np.random.rand(128)),
+            Document(id='doc1', embedding=np.random.rand(3)),
+            Document(id='doc2', embedding=np.random.rand(3)),
+            Document(id='doc3', embedding=np.random.rand(3)),
+            Document(id='doc4', embedding=np.random.rand(3)),
+            Document(id='doc5', embedding=np.random.rand(3)),
+            Document(id='doc6', embedding=np.random.rand(3)),
         ]
     )
 
@@ -106,7 +106,7 @@ def test_filter(docker_compose):
 
 @pytest.mark.parametrize(
     'metric, metric_name',
-    [('L2', 'euclid_similarity'), ('COSINE', 'cosine_similarity')],
+    [('L2', 'euclid_distance'), ('COSINE', 'cosine_distance')],
 )
 def test_search(metric, metric_name, docs, docker_compose):
     # test general/normal case
@@ -117,7 +117,9 @@ def test_search(metric, metric_name, docs, docker_compose):
 
     for doc in query:
         similarities = [t[metric_name].value for t in doc.matches[:, 'scores']]
-        assert sorted(similarities, reverse=True) == similarities
+        print(f"similarities = {similarities}")
+        assert sorted(similarities) == similarities
+        assert len(similarities) == len(docs)
 
 
 @pytest.mark.parametrize('limit', [1, 2, 3])


### PR DESCRIPTION
Previously, a list_like parameter has been added to the storage backends, this parameter we now want to introduce to the RedisIndexer.
This way, the list-like behaviour can be disabled the the [performance issues regarding the list-like behaviour](https://docarray.jina.ai/advanced/document-store/#performance-issue-caused-by-list-like-structure) removed ().

Solving this issue: https://github.com/docarray/docarray/issues/802